### PR TITLE
Minor fix in RT2

### DIFF
--- a/rest.rb
+++ b/rest.rb
@@ -935,7 +935,7 @@ post "/dspace-rest/items/:itemGUID/bitstreams" do |shortArk|
     if fileVersion
       info[:meta][:contentVersion] = case fileVersion
         # Pre-v6.8 terms
-        when /(Author final|Submitted) version/; 'AUTHOR_VERSION'
+        when /(Author's final|Submitted) version/; 'AUTHOR_VERSION'
         when "Published version"; 'PUBLISHER_VERSION'
         # Post-v6.8 terms
         when /(Publisher's|Published) version/; 'PUBLISHER_VERSION'


### PR DESCRIPTION
"Author's final version" is what's specified in the Elements deposit advice, so this change allows us to use the same in the version drop menu.