### PR TITLE
Pubdate

### DIFF
--- a/maps/prod/dspace-xwalk-out-deposit.xml
+++ b/maps/prod/dspace-xwalk-out-deposit.xml
@@ -10,6 +10,9 @@
       <xwalk:field-mapping to="elements-pub-id">
         <xwalk:field-source from="object.id" />
       </xwalk:field-mapping>
+      <xwalk:field-mapping to="reporting-date-1">
+        <xwalk:field-source from="object.reporting-date-1" />
+      </xwalk:field-mapping>
       <xwalk:field-mapping to="authors" is-list="true" separator="||&#xD;&#xA;">
         <xwalk:field-source from="authors">
           <xwalk:field-source value="start" prefix="$&#xD;&#xA;[start-person]" value-map="no-text" />
@@ -217,6 +220,7 @@
   <xwalk:field-authority-lists>
     <xwalk:field-authority-list name="eschol-upd-auth">
       <xwalk:field-authority field-name="elements-pub-id" />
+      <xwalk:field-authority field-name="reporting-date-1" />      
       <xwalk:field-authority field-name="authors" />
       <xwalk:field-authority field-name="editors" />
       <xwalk:field-authority field-name="groups" />

--- a/maps/qa/dspace-xwalk-out-deposit.xml
+++ b/maps/qa/dspace-xwalk-out-deposit.xml
@@ -10,6 +10,9 @@
       <xwalk:field-mapping to="elements-pub-id">
         <xwalk:field-source from="object.id" />
       </xwalk:field-mapping>
+      <xwalk:field-mapping to="reporting-date-1">
+        <xwalk:field-source from="object.reporting-date-1" />
+      </xwalk:field-mapping>
       <xwalk:field-mapping to="authors" is-list="true" separator="||&#xD;&#xA;">
         <xwalk:field-source from="authors">
           <xwalk:field-source value="start" prefix="$&#xD;&#xA;[start-person]" value-map="no-text" />
@@ -217,6 +220,7 @@
   <xwalk:field-authority-lists>
     <xwalk:field-authority-list name="eschol-upd-auth">
       <xwalk:field-authority field-name="elements-pub-id" />
+      <xwalk:field-authority field-name="reporting-date-1" />
       <xwalk:field-authority field-name="authors" />
       <xwalk:field-authority field-name="editors" />
       <xwalk:field-authority field-name="groups" />

--- a/rest.rb
+++ b/rest.rb
@@ -790,10 +790,13 @@ def processMetaUpdate(requestURL, itemID, metaHash, feedFile)
     d2 = removeNils(JSON.parse(jsonMeta.to_json))
     %w{pubRelation sourceFeedLink sourceID sourceName submitterEmail keywords}.each { |key| d2.delete(key) }
 
-    #puts "\nd1="; pp d1
-    #puts "\nd2="; pp d2
+    # FOR DEBUGGING, you can output the JSONs which are compared and saved to "diff"
+    # puts "\nd1="; pp d1
+    # puts "\nd2="; pp d2
+
     diff = JsonDiff.diff(d1, d2, include_was: true)
     puts "Anticipated diff:"; pp diff
+
     if diff.empty?
       puts "No anticipated diff; skipping update."
       return nil
@@ -804,8 +807,10 @@ def processMetaUpdate(requestURL, itemID, metaHash, feedFile)
 
     approveItem(itemID, { meta: jsonMeta }, replaceOnly: :metadata)
 
-    # During development, let's re-query the data to see what diffs there might be
-    # DS -- removed on 2023-12-13 to test effect on queue speed.
+    # FOR DEBUGGING, you can re-query the data to see what diffs there might be
+    # DS removed this on 2023-12-13 to speed up the processing queue: It sends
+    # an additional GET to eScholarship, practically doubling per-item processing time
+
     # newData = accessAPIQuery(itemQuery, { itemID: ["ID!", "ark:/13030/#{itemID}"] }, true).dig("item") or raise
     # diff = JsonDiff.diff(data, newData, include_was: true)
     # diff.reject! { |d| d['path'] == '/updated' }  # not interesting that 'updated' is changing

--- a/rest.rb
+++ b/rest.rb
@@ -161,15 +161,7 @@ def accessAPIQuery(query, vars = {}, privileged = false)
                  :headers => headers,
                  :body => { variables: varHash, query: query }.to_json)
     if response.code != 200
-
-      # POTENTIAL PROBLEM: When our graphQL returns non-200 (usually 500), error and exit.
       raise("Internal error (graphql): HTTP code #{response.code} - #{response.message}.\n" + "#{response.body}")
-
-      # POTENTIAL WORKAROUND: The following code prevents connectRT2 from passing graphQL's 500 errors
-      # (e.g. BigInt) to Elements. Instead, it prints the error, then proceeds operating with an empty string.
-      # puts "Returning empty graphQL results for testing purposes."
-      # dummy_data = {"item"=>{}}
-      # return dummy_data
     end
   rescue Exception => exc
     if (response && [500,502,504].include?(response.code) && response.body.length < 200) ||

--- a/transform.rb
+++ b/transform.rb
@@ -127,7 +127,9 @@ def parseMetadataEntries(feed)
     # Workaround 
     elsif key == 'suppFiles'
       puts ("Non-kewords double: suppFiles")
-      metaHash.key?(key) or metaHash[key] = value   # Take first one only (for now at least)
+      # metaHash.key?(key) or metaHash[key] = value   # Take first one only (for now at least)
+      metaHash[key] ||= []
+      metaHash[key] << value
 
     elsif metaHash.key?(key)
 

--- a/transform.rb
+++ b/transform.rb
@@ -124,12 +124,11 @@ def parseMetadataEntries(feed)
     elsif key == 'proceedings' 
       metaHash.key?(key) or metaHash[key] = value   # Take first one only (for now at least)
 
-    # Workaround 
+    # Workaround for supp, take only the first value.
+    # This 
     elsif key == 'suppFiles'
       puts ("Non-kewords double: suppFiles")
       metaHash.key?(key) or metaHash[key] = value   # Take first one only (for now at least)
-      # metaHash[key] ||= []
-      # metaHash[key] << value
 
     elsif metaHash.key?(key)
 
@@ -150,12 +149,16 @@ def parseMetadataEntries(feed)
 end
 
 ###################################################################################################
-def convertPubDate(pubDate)
+def convertPubDate(pubDate, reportingDate1)
+
+  # The fallback is used if pubDate = nil.
+  fallback_date = reportingDate1 ? reportingDate1 : Date.today.iso8601
+
   case pubDate
     when /^\d\d\d\d-[01]\d-[0123]\d$/; pubDate
     when /^\d\d\d\d-[01]\d$/;          "#{pubDate}-01"
     when /^\d\d\d\d$/;                 "#{pubDate}-01-01"
-    when nil;                          Date.today.iso8601
+    when nil;                          fallback_date
     else;                              raise("Unrecognized date.issued format: #{pubDate.inspect}")
   end
 end
@@ -437,7 +440,7 @@ def elementsToJSON(oldData, elemPubID, submitterEmail, metaHash, ark, feedFile)
   data[:ucpmsPubType] = elementsPubType
 
   # History
-  data[:published] = convertPubDate(metaHash.delete('publication-date'))
+  data[:published] = convertPubDate(metaHash.delete('publication-date'),metaHash.delete('reporting-date-1'))
   data[:submitterEmail] = submitterEmail
 
   # Custom Citation Field

--- a/transform.rb
+++ b/transform.rb
@@ -149,19 +149,26 @@ def parseMetadataEntries(feed)
 end
 
 ###################################################################################################
-def convertPubDate(pubDate, reportingDate1)
-
-  # The fallback is used if pubDate = nil.
-  fallback_date = reportingDate1 ? reportingDate1 : Date.today.iso8601
-
+def convertPubDate(pubDate, reportingDate1, depositDate)
+  
+  # Note: depositDate is the eScholarship item's deposit date
+  fallback_date = ''
+  if reportingDate1 != nil
+    fallback_date = reportingDate1
+  elsif depositDate != nil
+    fallback_date = depositDate
+  else
+    fallback_date = Date.today.iso8601
+  end
+  
   case pubDate
     when /^\d\d\d\d-[01]\d-[0123]\d$/; pubDate
     when /^\d\d\d\d-[01]\d$/;          "#{pubDate}-01"
     when /^\d\d\d\d$/;                 "#{pubDate}-01-01"
     when nil;                          fallback_date
     else;                              raise("Unrecognized date.issued format: #{pubDate.inspect}")
-  end
-end
+  end   
+end 
 
 ###################################################################################################
 def convertFileVersion(fileVersion)
@@ -440,7 +447,7 @@ def elementsToJSON(oldData, elemPubID, submitterEmail, metaHash, ark, feedFile)
   data[:ucpmsPubType] = elementsPubType
 
   # History
-  data[:published] = convertPubDate(metaHash.delete('publication-date'),metaHash.delete('reporting-date-1'))
+  data[:published] = convertPubDate(metaHash.delete("publication-date"),metaHash.delete("reporting-date-1"),metaHash["deposit-date"])
   data[:submitterEmail] = submitterEmail
 
   # Custom Citation Field

--- a/transform.rb
+++ b/transform.rb
@@ -375,6 +375,9 @@ end
 # existing eschol data in, it will be retained if Elements doesn't override it.
 def elementsToJSON(oldData, elemPubID, submitterEmail, metaHash, ark, feedFile)
 
+  # FOR DEBUGGING, you can output the raw metaHash (the Elements input)
+  # puts(metaHash)
+
   # eSchol ARK identifier (provisional ID minted previously for new items)
   data = oldData ? oldData.clone : {}
   data[:id] = ark

--- a/transform.rb
+++ b/transform.rb
@@ -127,9 +127,9 @@ def parseMetadataEntries(feed)
     # Workaround 
     elsif key == 'suppFiles'
       puts ("Non-kewords double: suppFiles")
-      # metaHash.key?(key) or metaHash[key] = value   # Take first one only (for now at least)
-      metaHash[key] ||= []
-      metaHash[key] << value
+      metaHash.key?(key) or metaHash[key] = value   # Take first one only (for now at least)
+      # metaHash[key] ||= []
+      # metaHash[key] << value
 
     elsif metaHash.key?(key)
 

--- a/transform.rb
+++ b/transform.rb
@@ -118,13 +118,15 @@ def parseMetadataEntries(feed)
       metaHash[key] ||= []
       metaHash[key] << value
 
-    # These keys may also be multiple; However, but aren't used in the PUT req.
+    # These keys may also be multiple; However, they aren't used in the PUT req.
     elsif key == 'subjects' || key == 'disciplines'
       puts ("Non-kewords double key: #{key} -- Pushing value into array: #{value}")
       metaHash[key] ||= []
       metaHash[key] << value
     
-    # Proceedings can also contain multiples, but aren't used in the PUT req.
+    # Proceedings can also contain multiples, but this is rare in practice.
+    # In eScholarship, this is used in place of the journal title for conference papers,
+    # We only take the first value to avoid 500 errors.
     elsif key == 'proceedings' 
       metaHash.key?(key) or metaHash[key] = value   # Take first one only (for now at least)
 
@@ -132,7 +134,7 @@ def parseMetadataEntries(feed)
     # Note: Elements sends several /bitstream requests with which it populates it's
     #       supplementary file info in its UI.
     elsif key == 'suppFiles'
-      puts ("Non-kewords double: suppFiles")
+      puts ("Non-keywords double: suppFiles")
       metaHash.key?(key) or metaHash[key] = value   # Take first one only (for now at least)
 
     # Otherwise, When an elements pub has > 1 eScholarship record, throw an error and halt.
@@ -450,7 +452,11 @@ def elementsToJSON(oldData, elemPubID, submitterEmail, metaHash, ark, feedFile)
   data[:ucpmsPubType] = elementsPubType
 
   # History
-  data[:published] = convertPubDate(metaHash.delete("publication-date"),metaHash.delete("reporting-date-1"),metaHash["deposit-date"])
+  data[:published] = convertPubDate(
+    metaHash.delete("publication-date"),
+    metaHash.delete("reporting-date-1"),
+    metaHash["deposit-date"]
+  )
   data[:submitterEmail] = submitterEmail
 
   # Custom Citation Field

--- a/transform.rb
+++ b/transform.rb
@@ -112,33 +112,33 @@ def parseMetadataEntries(feed)
     key = ent.text_at('key')
     value = ent.text_at('value')
 
+    # Multiple keywords are expected.
+    # This array is handled later, via the convertKeywords() function.
     if key == 'keywords'
       metaHash[key] ||= []
       metaHash[key] << value
 
+    # These keys may also be multiple; However, but aren't used in the PUT req.
     elsif key == 'subjects' || key == 'disciplines'
       puts ("Non-kewords double key: #{key} -- Pushing value into array: #{value}")
       metaHash[key] ||= []
       metaHash[key] << value
-      
+    
+    # Proceedings can also contain multiples, but aren't used in the PUT req.
     elsif key == 'proceedings' 
       metaHash.key?(key) or metaHash[key] = value   # Take first one only (for now at least)
 
-    # Workaround for supp, take only the first value.
-    # This 
+    # Similar to Proceedings above.
+    # Note: Elements sends several /bitstream requests with which it populates it's
+    #       supplementary file info in its UI.
     elsif key == 'suppFiles'
       puts ("Non-kewords double: suppFiles")
       metaHash.key?(key) or metaHash[key] = value   # Take first one only (for now at least)
 
+    # Otherwise, When an elements pub has > 1 eScholarship record, throw an error and halt.
+    # See above for workaround strategies if required.
     elsif metaHash.key?(key)
-
-      # POTENTIAL PROBLEM: When an elements pub has > 1 eScholarship record,
-      # throw an error and halt processing.
       raise("double key #{key}")
-
-      # POTENTIAL WORKAROUND: Take only the first value and do nothing.
-      # puts("Double key: #{key} -- Taking the first value.")
-      # nil
 
     else
       metaHash[key] = value


### PR DESCRIPTION
This branch mainly changes how publications from Elements without publication dates are handled when syncing to eScholarship:

- Deposit xwalks now output "reporting-date-1" 
- convertPubDates() (called from elementsToJSON) now takes multiple date values (publication date, Elements' reporting-date-1, and eScholarship's deposit date), and uses an IF-tree to select a fallback date if the publication date is nil.
- Several contextual comments have been added to various commented-out debugging options and potentially ambiguous metadata-parsing behaviors.