### PR TITLE
Unit assignment fix

### DIFF
--- a/transform.rb
+++ b/transform.rb
@@ -469,7 +469,7 @@ def elementsToJSON(oldData, elemPubID, submitterEmail, metaHash, ark, feedFile)
 end
 
 ###################################################################################################
-# If the depositor is rgpo-nonuc but there's RGPO-related grant(s), thow error and halt
+# If the depositor is rgpo-nonuc but there's no RGPO-related grant(s), thow error and halt
 def checkNonUCDepositorsGrants(funderTypeDisplayName, depositorGroup, ark)
 
   # Pass through standard UC groups

--- a/transform.rb
+++ b/transform.rb
@@ -378,7 +378,7 @@ end
 def elementsToJSON(oldData, elemPubID, submitterEmail, metaHash, ark, feedFile)
 
   # FOR DEBUGGING, you can output the raw metaHash (the Elements input)
-  puts(metaHash)
+  # puts(metaHash)
 
   # Check for non-uc depositors depositing without grants (userErrorHalt if there's a problem)
   checkNonUCDepositorsGrants(metaHash['funder-type-display-name'], metaHash['depositor-group'], ark)
@@ -467,7 +467,6 @@ def elementsToJSON(oldData, elemPubID, submitterEmail, metaHash, ark, feedFile)
 
   # Check for non-uc depositors and non-uc items without grants.
   # This is easier to handle after the tranforms.
-  # data = nonUCChecks(data, metaHash['depositor-group'])
 
   # All done.
   return data
@@ -479,19 +478,23 @@ def checkNonUCDepositorsGrants(funderTypeDisplayName, depositorGroup, ark)
 
   # Pass through standard UC groups
   if depositorGroup == 'rgpo-nonuc'
-    nonUCGrantFound = false
+    
+    if funderTypeDisplayName == nil
+      userErrorHalt(ark, "Deposit not accepted: publication must be linked to a RGPO grant (CBCP, CBCRP, TRDRP, etc). Please return to the \"link grant\" screen or contact us for assistance.")
+    else
+      nonUCGrantFound = false
 
-    # Split the funder types; loop; set the boolean and break if found.
-    funderTypeDisplayName.split("|").each { |funder|
-      if ["RGPO (CBCRP) Award", "RGPO (CHRP) Award", "RGPO (TRDRP) Award", "RGPO (UCRI) Award"].include? funder
-        nonUCGrantFound = true
-        break
+      # Split the funder types; loop; set the boolean and break if found.
+      funderTypeDisplayName.split("|").each { |funder|
+        if ["RGPO (CBCRP) Award", "RGPO (CHRP) Award", "RGPO (TRDRP) Award", "RGPO (UCRI) Award"].include? funder
+          nonUCGrantFound = true
+          break
+        end
+      }
+
+      if nonUCGrantFound == false
+        userErrorHalt(ark, "Deposit not accepted: publication must be linked to a RGPO grant (CBCP, CBCRP, TRDRP, etc). Please return to the \"link grant\" screen or contact us for assistance.")
       end
-    }
-
-    if nonUCGrantFound == false
-      userErrorHalt(ark, "Deposit not accepted: Non-UC RGPO grantees must link " +
-        "an appropriate RGPO grant (CBCRP, CHRP, TRDRP, UCRI) before depositing.")
     end
 
   end

--- a/transform.rb
+++ b/transform.rb
@@ -32,7 +32,7 @@ $groupToCampus = { 684 => 'lbnl',
                    1254 => 'anrcs',
                    1164 => 'ucop' }
 
-$rgpoPrograms = ["RGPO", "CBCRP", "CHRP", "TRDRP", "UCRI"]
+$rgpoPrograms = ["CBCRP", "CHRP", "TRDRP", "UCRI"]
 
 ###################################################################################################
 $repecIDs = {}


### PR DESCRIPTION
Updates the RGPO unit assignment to work better with the new group structure:

- Checks for "RGPO" text in group name && grants && date > 2017
- Loop the grant names
- - Loop the RGPO program strings (TRDRP, CHRP, etc). If the grant name includes one of these, add the program_rw group, and also rgpo_rw.

(note: rgpo_units is a set, so duplicate *_rw groups will be filtered automatically)