### PR TITLE
Hyperauthor

### DIFF
--- a/rest.rb
+++ b/rest.rb
@@ -792,6 +792,7 @@ def checkDiff(old_data, new_data)
     submitterEmail
     fpage
     lpage
+    journal
     volume
     issue
     issn

--- a/rest.rb
+++ b/rest.rb
@@ -763,6 +763,9 @@ def checkDiff(old_data, new_data)
     return obj
   end
 
+  puts "NEW AUTHOR COUNT: #{new_data[:authors].length}"
+  puts "HYPERAUTHOR PAPER" if (new_data[:authors].length > 1000)
+
   # Remove keys with nil values
   old_data = removeNils(old_data)
   new_data = removeNils(new_data)
@@ -789,6 +792,9 @@ def checkDiff(old_data, new_data)
     submitterEmail
     fpage
     lpage
+    volume
+    issue
+    issn
   }
 
   unneeded_comp_keys.each { |key| 

--- a/rest.rb
+++ b/rest.rb
@@ -816,7 +816,7 @@ def processMetaUpdate(requestURL, itemID, metaHash, feedFile)
     puts "Anticipated diff:"; pp diff
 
     if (diff.length() > 100) && (Date.today - Date.strptime(d1['published'], "%Y-%m-%d") > 90)
-      puts "Hyperauthor filter triggered."
+      puts "Hyperauthor filter triggered #{itemID}"
       diff = filterHyperauthorUpdates(diff)
       puts "Filtered for hyperauthor updates:"; pp diff
     end

--- a/rest.rb
+++ b/rest.rb
@@ -40,7 +40,7 @@ $feedTmpDir = "#{$homeDir}/apache/htdocs/bitstreamTmp"
 ITEM_META_FIELDS = %{
   id
   title
-  authors(first:500) {
+  authors() {
     nodes {
       email
       orcid
@@ -54,7 +54,7 @@ ITEM_META_FIELDS = %{
       }
     }
   }
-  contributors(first:500) {
+  contributors() {
     nodes {
       role
       email
@@ -815,11 +815,11 @@ def processMetaUpdate(requestURL, itemID, metaHash, feedFile)
     diff = JsonDiff.diff(d1, d2, include_was: true)
     puts "Anticipated diff:"; pp diff
 
-    if (diff.length() > 20) and (Date.today - Date.strptime(d1['published'], "%Y-%m-%d") > 90)
-      puts "Hyperauthor update detected."
-      diff = filterHyperauthorUpdates(diff)
-      puts "Filtered for hyperauthor updates:"; pp diff
-    end
+    # if (diff.length() > 20) and (Date.today - Date.strptime(d1['published'], "%Y-%m-%d") > 90)
+    #   puts "Hyperauthor update detected."
+    #   diff = filterHyperauthorUpdates(diff)
+    #   puts "Filtered for hyperauthor updates:"; pp diff
+    # end
 
     if diff.empty?
       puts "No anticipated diff; skipping update."

--- a/rest.rb
+++ b/rest.rb
@@ -752,21 +752,20 @@ def removeNils(struc)
 end
 
 ###################################################################################################
+# Removes any author operations with /author/# > 20
 def filterHyperauthorUpdates(diff)
-  # Removes any author operations with /author/# > 20
-  begin
-    filtered_diff = []
+  filtered_diff = []
 
-    diff.each { |update|
-      path = update["path"]
-      if (path.include? "author")
-        next if path.split('/')[2].to_i > 20
-      end
-      filtered_diff << update
-    }
+  diff.each { |update|
+    path = update["path"]
+    if (path.include? "author")
+      next if path.split('/')[2].to_i > 20
+    end
+    filtered_diff << update
+  }
 
-    return filtered_diff
-  end
+  return filtered_diff
+end
 
 ###################################################################################################
 def processMetaUpdate(requestURL, itemID, metaHash, feedFile)
@@ -816,8 +815,10 @@ def processMetaUpdate(requestURL, itemID, metaHash, feedFile)
     diff = JsonDiff.diff(d1, d2, include_was: true)
     puts "Anticipated diff:"; pp diff
 
-    diff = filterHyperauthorUpdates(diff)
-    puts "Filtered for hyperauthor updates:"; pp diff
+    if (Date.today - Date.strptime(d1['published'], "%Y-%m-%d") > 90)
+      diff = filterHyperauthorUpdates(diff)
+      puts "Filtered for hyperauthor updates:"; pp diff
+    end
 
     if diff.empty?
       puts "No anticipated diff; skipping update."

--- a/rest.rb
+++ b/rest.rb
@@ -40,7 +40,7 @@ $feedTmpDir = "#{$homeDir}/apache/htdocs/bitstreamTmp"
 ITEM_META_FIELDS = %{
   id
   title
-  authors() {
+  authors(first: 500) {
     nodes {
       email
       orcid
@@ -54,7 +54,7 @@ ITEM_META_FIELDS = %{
       }
     }
   }
-  contributors() {
+  contributors(first: 500) {
     nodes {
       role
       email
@@ -759,7 +759,7 @@ def filterHyperauthorUpdates(diff)
   diff.each { |update|
     path = update["path"]
     if (path.include? "author")
-      next if path.split('/')[2].to_i > 20
+      next if (path.split('/')[2].to_i > 20)
     end
     filtered_diff << update
   }
@@ -815,11 +815,11 @@ def processMetaUpdate(requestURL, itemID, metaHash, feedFile)
     diff = JsonDiff.diff(d1, d2, include_was: true)
     puts "Anticipated diff:"; pp diff
 
-    # if (diff.length() > 20) and (Date.today - Date.strptime(d1['published'], "%Y-%m-%d") > 90)
-    #   puts "Hyperauthor update detected."
-    #   diff = filterHyperauthorUpdates(diff)
-    #   puts "Filtered for hyperauthor updates:"; pp diff
-    # end
+    if (diff.length() > 100) && (Date.today - Date.strptime(d1['published'], "%Y-%m-%d") > 90)
+      puts "Hyperauthor filter triggered."
+      diff = filterHyperauthorUpdates(diff)
+      puts "Filtered for hyperauthor updates:"; pp diff
+    end
 
     if diff.empty?
       puts "No anticipated diff; skipping update."

--- a/rest.rb
+++ b/rest.rb
@@ -752,6 +752,23 @@ def removeNils(struc)
 end
 
 ###################################################################################################
+def filterHyperauthorUpdates(diff)
+  # Removes any author operations with /author/# > 20
+  begin
+    filtered_diff = []
+
+    diff.each { |update|
+      path = update["path"]
+      if (path.include? "author")
+        next if path.split('/')[2].to_i > 20
+      end
+      filtered_diff << update
+    }
+
+    return filtered_diff
+  end
+
+###################################################################################################
 def processMetaUpdate(requestURL, itemID, metaHash, feedFile)
 
   begin
@@ -798,6 +815,9 @@ def processMetaUpdate(requestURL, itemID, metaHash, feedFile)
 
     diff = JsonDiff.diff(d1, d2, include_was: true)
     puts "Anticipated diff:"; pp diff
+
+    diff = filterHyperauthorUpdates(diff)
+    puts "Filtered for hyperauthor updates:"; pp diff
 
     if diff.empty?
       puts "No anticipated diff; skipping update."

--- a/rest.rb
+++ b/rest.rb
@@ -815,7 +815,8 @@ def processMetaUpdate(requestURL, itemID, metaHash, feedFile)
     diff = JsonDiff.diff(d1, d2, include_was: true)
     puts "Anticipated diff:"; pp diff
 
-    if (Date.today - Date.strptime(d1['published'], "%Y-%m-%d") > 90)
+    if (diff.length() > 20) and (Date.today - Date.strptime(d1['published'], "%Y-%m-%d") > 90)
+      puts "Hyperauthor update detected."
       diff = filterHyperauthorUpdates(diff)
       puts "Filtered for hyperauthor updates:"; pp diff
     end

--- a/transform.rb
+++ b/transform.rb
@@ -382,17 +382,11 @@ def elementsToJSON(oldData, elemPubID, submitterEmail, metaHash, ark, feedFile)
   elementsPubStatus = metaHash['publication-status'] || nil
   elementsIsReviewed = metaHash.delete('is-reviewed') || nil
   
+  # Infer peer review status if it's not explicitly set
   data[:isPeerReviewed] = getDefaultPeerReview(elementsIsReviewed, elementsPubType, elementsPubStatus)
 
+  # Convert Elements pub types and statuses to eSchol enum values
   data[:type] = convertPubType(elementsPubType)
-  data[:isPeerReviewed] = true  # assume all Elements items are peer reviewed
-  if (elementsPubType == 'preprint' ||
-     (elementsPubType == 'journal-article' &&
-       (elementsPubStatus == 'In preparation' ||
-        elementsPubStatus == 'Submitted' ||
-        elementsPubStatus == 'Unpublished') ) )  
-    data[:isPeerReviewed] = false  # assume preprints are not peer reviewed
-  end  
   data[:pubRelation] = convertPubStatus(metaHash.delete('publication-status'))
   
   embargo = assignEmbargo(metaHash)


### PR DESCRIPTION
Branch cleanup and hyperauthor changes:
- GraphQL "first" parm for authors and contributors 500 --> 10k
- Replaced the metadata update JSON diff comparison to native ruby hash comparison
- Removed the second (overwriting) peer review calculation, using instead the function `getDefaultPeerReview`. (Logic was confirmed with Alainna and Geoff).
- Note: Various earlier commits include strategies for hyperauthor filtering that were eventually removed. Check the "files changed" for the final updates going into main.