### PR TITLE
Removing overriding peer review calc

### DIFF
--- a/transform.rb
+++ b/transform.rb
@@ -387,16 +387,6 @@ def elementsToJSON(oldData, elemPubID, submitterEmail, metaHash, ark, feedFile)
   elementsIsReviewed = metaHash.delete('is-reviewed') || nil
   
   data[:isPeerReviewed] = getDefaultPeerReview(elementsIsReviewed, elementsPubType, elementsPubStatus)
-
-  data[:type] = convertPubType(elementsPubType)
-  data[:isPeerReviewed] = true  # assume all Elements items are peer reviewed
-  if (elementsPubType == 'preprint' ||
-     (elementsPubType == 'journal-article' &&
-       (elementsPubStatus == 'In preparation' ||
-        elementsPubStatus == 'Submitted' ||
-        elementsPubStatus == 'Unpublished') ) )  
-    data[:isPeerReviewed] = false  # assume preprints are not peer reviewed
-  end  
   data[:pubRelation] = convertPubStatus(metaHash.delete('publication-status'))
   
   embargo = assignEmbargo(metaHash)

--- a/transform.rb
+++ b/transform.rb
@@ -387,6 +387,7 @@ def elementsToJSON(oldData, elemPubID, submitterEmail, metaHash, ark, feedFile)
   elementsIsReviewed = metaHash.delete('is-reviewed') || nil
   
   data[:isPeerReviewed] = getDefaultPeerReview(elementsIsReviewed, elementsPubType, elementsPubStatus)
+  data[:type] = convertPubType(elementsPubType)
   data[:pubRelation] = convertPubStatus(metaHash.delete('publication-status'))
   
   embargo = assignEmbargo(metaHash)


### PR DESCRIPTION
Removes the overriding second peer review calculation.

### Details:
- Duplicate peer review calc first noticed about a year ago
- Detailed discussions w/ Alainna, confirmed the first method is correct
- Change was made and live on prod...
- However, I believe I accidentally reverted this when working on the PMID sync changes.
   - I did a poor job keeping a clean git record from this period, as I was working on the code both locally and live on staging.

### Edge case
During discussions, we identified one edge case, which we decided was small enough to not worry about: There are about 10k publications in eSchol with both "type" and "peer review" null values. These are very old, before "type" was required in eSchol, and (we think) mostly or entirely subi-submitted, meaning they wouldn't be processed for diff syncing by elements. Pubs with these features would have their "null" peer review values set to "false" if they ran through this code.